### PR TITLE
Rename linkedin_username to linkedin_url for semantic clarity

### DIFF
--- a/ice_breaker.py
+++ b/ice_breaker.py
@@ -18,8 +18,8 @@ from output_parsers import (
 def ice_break_with(
     name: str,
 ) -> Tuple[Summary, TopicOfInterest, IceBreaker, str]:
-    linkedin_username = linkedin_lookup_agent(name=name)
-    linkedin_data = scrape_linkedin_profile(linkedin_profile_url=linkedin_username)
+    linkedin_url = linkedin_lookup_agent(name=name)
+    linkedin_data = scrape_linkedin_profile(linkedin_profile_url=linkedin_url)
 
     twitter_username = twitter_lookup_agent(name=name)
     tweets = scrape_user_tweets_mock(username=twitter_username)


### PR DESCRIPTION
This PR renames the `linkedin_username` variable to `linkedin_url` throughout the codebase for better semantic clarity.

The variable contains a LinkedIn profile URL (not a username), so this rename better reflects its actual content.

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)